### PR TITLE
fix: fix load more tickets - EXO-69035

### DIFF
--- a/glpi-integration-services/src/main/java/org/exoplatform/glpi/service/GLPIServiceImpl.java
+++ b/glpi-integration-services/src/main/java/org/exoplatform/glpi/service/GLPIServiceImpl.java
@@ -209,12 +209,15 @@ public class GLPIServiceImpl implements GLPIService {
     if (httpGet == null) {
       return null;
     }
+    List<GlpiTicket> tickets = new ArrayList<>();
     try {
-      List<GlpiTicket> tickets = new ArrayList<>();
       HttpResponse httpResponse = httpClient.execute(httpGet);
       String responseString = new BasicResponseHandler().handleResponse(httpResponse);
       EntityUtils.consume(httpResponse.getEntity());
       JSONObject jsonResponse = new JSONObject(responseString);
+      if (!jsonResponse.has("data")) {
+        return tickets;
+      }
       JSONArray jsonArray = jsonResponse.getJSONArray("data");
       jsonArray.forEach(object -> {
         GlpiTicket ticket = new GlpiTicket();
@@ -250,7 +253,7 @@ public class GLPIServiceImpl implements GLPIService {
     } finally {
       killSession(sessionToken);
     }
-    return null;
+    return tickets;
   }
 
   private List<Object> parseComments(Object comments) {

--- a/glpi-integration-webapps/src/main/webapp/vue-app/glpi/components/GlpiApp.vue
+++ b/glpi-integration-webapps/src/main/webapp/vue-app/glpi/components/GlpiApp.vue
@@ -77,7 +77,7 @@ export default {
       hasValidUserToken: false,
       glpiSettings: null,
       tickets: [],
-      pageSize: 8,
+      pageSize: 10,
       limit: 0,
       offset: 0,
       loading: false,
@@ -135,8 +135,8 @@ export default {
       this.loading = !loadMore;
       this.isLoadingMore = loadMore;
       return this.$glpiService.getGLPITickets(offset, limit + 1).then(tickets => {
-        this.tickets.push(...tickets);
-        this.hasMore = tickets?.length > this.limit - this.offset;
+        this.tickets.push(...tickets.slice(0, limit));
+        this.hasMore = tickets?.length > limit - offset;
       }).finally(() => {
         this.loading = false;
         this.isLoadingMore = false;


### PR DESCRIPTION
prior to this change, load more button displayed even if no more tickets to load, and throw exception wheb glpi return no data. this PR makes sure to avoid such exception and show the load more button only if it's needed