### PR TITLE
fix: Unable to open ticket details - EXO-69061

### DIFF
--- a/glpi-integration-services/src/main/java/org/exoplatform/glpi/service/GLPIServiceImpl.java
+++ b/glpi-integration-services/src/main/java/org/exoplatform/glpi/service/GLPIServiceImpl.java
@@ -278,11 +278,17 @@ public class GLPIServiceImpl implements GLPIService {
   private List<GlpiUser> getGLPIUsersInfo(Object assignees, String sessionToken) {
     List<GlpiUser> GLPIUsers = new ArrayList<>();
     if (assignees instanceof String) {
-      GLPIUsers.add(getGLPIUserInfo(Long.parseLong((String) assignees), sessionToken));
+      GlpiUser glpiUser = getGLPIUserInfo(Long.parseLong((String) assignees), sessionToken);
+      if (glpiUser != null) {
+        GLPIUsers.add(glpiUser);
+      }
     } else {
       ((JSONArray) assignees).forEach(object -> {
         String glpiUserId = (String) object;
-        GLPIUsers.add(getGLPIUserInfo(Long.parseLong(glpiUserId), sessionToken));
+        GlpiUser glpiUser = getGLPIUserInfo(Long.parseLong(glpiUserId), sessionToken);
+        if (glpiUser != null) {
+          GLPIUsers.add(glpiUser);
+        }
       });
     }
     return GLPIUsers;


### PR DESCRIPTION
Prior to this change, when user is not authorized to read ticket assignee, the ticket details can't be opened because of list of null assignees that causes an issue in the template. 
This PR makes sure to not add the assignee to the returned list when it's null and avoid such issue